### PR TITLE
Add &to (To Layer) behavior

### DIFF
--- a/api/services/zmk/data/zmk-behaviors.json
+++ b/api/services/zmk/data/zmk-behaviors.json
@@ -76,6 +76,11 @@
     "params": ["layer"]
   },
   {
+    "code": "&to",
+    "name": "To Layer",
+    "params": ["layer"]
+  },
+  {
     "code": "&tog",
     "name": "Toggle Layer",
     "params": ["layer"]


### PR DESCRIPTION
Added a new behavior - &to.
Tested with a local editor, the firmware was built and flashed successfully.

Sources:
https://zmk.dev/docs/behaviors/layers#to-layer
https://github.com/nickcoutsos/keymap-editor/blob/main/api/services/zmk/data/zmk-behaviors.json