### PR TITLE
Remove hardcoded column separation

### DIFF
--- a/api/services/zmk/layout.js
+++ b/api/services/zmk/layout.js
@@ -36,7 +36,6 @@ function renderTable (layout, layer, opts={}) {
       (row[i] || []).length
       + columnSeparator.length
       + (useQuotes ? 2 : 0) // wrapping with quotes adds 2 characters
-      + (i === 6 ? 10 : 0) // sloppily add a little space between halves (right half starts at column 6)
     ))
   ))
 


### PR DESCRIPTION
This line was a included to enforce separation of bindings for the left and right half of my keyboard specifically. For any other keyboard, including the advantage 360 this doesn't make sense and impacts the readability of the generated keymap code.

In the original editor I've removed this, since the same effect can be achieved by incrementing the layout's `"col"` properties for all of the keys in the right half.